### PR TITLE
feat: cut requests by configured time (MAPCO-3776)

### DIFF
--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -46,6 +46,9 @@ server {
     client_header_buffer_size   12288; # 12K
     large_client_header_buffers 4 12288; # 12K
     fastcgi_read_timeout        300;
+    uwsgi_read_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
+    uwsgi_send_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
+    uwsgi_connect_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
     location /liveness {
         access_log    off;
         log_not_found off;

--- a/helm/config/mapProxyUwsgi.ini
+++ b/helm/config/mapProxyUwsgi.ini
@@ -25,7 +25,7 @@ reload-on-rss = 2048                 ; Restart workers after this much resident 
 buffer-size = 14336                  ; 14K, Set the internal buffer size for uwsgi packet parsing. Default is 4k. 
 worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
 wsgi-disable-file-wrapper = true
-harakiri = 60
+harakiri = {{ .Values.mapproxy.uwsgi.timeoutSeconds }}
 py-callos-afterfork = true           ; allow workers to trap signals
 ; TODO: using default usgi config untill we figure out the best configuration
 ; cheaper-algo = busyness

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -160,6 +160,7 @@ mapproxy:
     processes: 6
     threads: 2
     disableLogging: true
+    timeoutSeconds: 8
     statsServer:
       enabled: false
       stats: 1717


### PR DESCRIPTION
PR Description: Mapproxy - Implement request timeout handling

Mission: Cut requests after 8 seconds to prevent long-running requests from impacting server performance.

Changes Made: Added the following uWSGI directives to handle request timeouts:

uwsgi_read_timeout
uwsgi_send_timeout
uwsgi_connect_timeout